### PR TITLE
Fix mobile scrolling

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -20,10 +20,10 @@
 
 @layer base {
   body {
-    @apply bg-secondary overflow-hidden leading-relaxed;
+    @apply bg-secondary overflow-x-hidden leading-relaxed;
   }
   .page {
-    @apply w-full h-screen overflow-hidden;
+    @apply w-full min-h-screen overflow-x-hidden;
   }
   .h1 {
     @apply text-[35px] leading-tight md:text-[60px] md:leading-[1.3] mb-8 font-semibold;


### PR DESCRIPTION
## Summary
- let pages grow taller than the screen
- keep horizontal overflow hidden

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685899a88020832b8eafe186e316249a