### PR TITLE
Fix typos in text

### DIFF
--- a/components/ServiceSlider.js
+++ b/components/ServiceSlider.js
@@ -39,7 +39,7 @@ const serviceData = [
   {
     icon: <RxRocket />,
     title: 'Deploy',
-    shortDescription: 'It is important you give your vision a chnace',
+    shortDescription: 'It is important you give your vision a chance',
     fullDescription: "With knowledge in deployment stages we can work together to make sure your vision makes it"
   },
 ];

--- a/pages/work/index.js
+++ b/pages/work/index.js
@@ -28,7 +28,7 @@ const Work = () => {
           animate="show"
           exit="hidden"
           className='mb-4 max-w-[400px] mx-auto lg:mx-0'>
-            Here, you can find a variety of projects that show my capacity to learn new technologies. The purpose of these projects was to put into practice different knowledge adquired. You will be surprised how every project is written in a different language and uses different techniques, feel free to reach out if you have any questions about them. 
+            Here, you can find a variety of projects that show my capacity to learn new technologies. The purpose of these projects was to put into practice different knowledge acquired. You will be surprised how every project is written in a different language and uses different techniques, feel free to reach out if you have any questions about them.
           </motion.p>
         </div>
         <motion.div


### PR DESCRIPTION
## Summary
- fix a typo in the Work page
- fix a typo in ServiceSlider

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685da4f10b2c832bab0d6fd864cf5413